### PR TITLE
Update baseline to point to main branch of FunctionalDataStructures

### DIFF
--- a/BaselineOfSmallKanren.package/BaselineOfSmallKanren.class/instance/baseline..st
+++ b/BaselineOfSmallKanren.package/BaselineOfSmallKanren.class/instance/baseline..st
@@ -6,7 +6,7 @@ baseline: spec
 		do: [
 			spec 
 				baseline: 'Cons' with: [ spec repository: 'github://emdonahue/Cons' ];
-				baseline: 'FunctionalDataStructures' with: [ spec repository: 'github://emdonahue/FunctionalDataStructures' ];
+				baseline: 'FunctionalDataStructures' with: [ spec repository: 'github://emdonahue/FunctionalDataStructures:main' ];
 				baseline: 'Contracts' with: [ spec repository: 'github://emdonahue/Contracts' ];			
 				package: 'SmallKanren-Core' with: [ spec requires: #('Cons' 'FunctionalDataStructures') ];
 				package: 'SmallKanren-Tests' with: [ spec requires: #('SmallKanren-Core' 'Cons' 'Contracts' 'FunctionalDataStructures') ] ]


### PR DESCRIPTION
Update baseline to point to `main` branch of FunctionalDataStructures.